### PR TITLE
Fix image file names for DC3

### DIFF
--- a/air/Douglas_DC3.dat
+++ b/air/Douglas_DC3.dat
@@ -145,13 +145,13 @@ range=2400
 Constraint[Next][0]=none
 Constraint[Prev][0]=none
 
-EmptyImage[E]=./images/Douglas_DC3_Mail.1.2
-EmptyImage[SE]=./images/Douglas_DC3_Mail.1.3
-EmptyImage[S]=./images/Douglas_DC3_Mail.1.4
-EmptyImage[SW]=./images/Douglas_DC3_Mail.1.5
-EmptyImage[W]=./images/Douglas_DC3_Mail.1.6
-EmptyImage[NW]=./images/Douglas_DC3_Mail.1.7
-EmptyImage[N]=./images/Douglas_DC3_Mail.1.0
-EmptyImage[NE]=./images/Douglas_DC3_Mail.1.1
+EmptyImage[E]=./images/Douglas_DC3_mail.1.2
+EmptyImage[SE]=./images/Douglas_DC3_mail.1.3
+EmptyImage[S]=./images/Douglas_DC3_mail.1.4
+EmptyImage[SW]=./images/Douglas_DC3_mail.1.5
+EmptyImage[W]=./images/Douglas_DC3_mail.1.6
+EmptyImage[NW]=./images/Douglas_DC3_mail.1.7
+EmptyImage[N]=./images/Douglas_DC3_mail.1.0
+EmptyImage[NE]=./images/Douglas_DC3_mail.1.1
 
 -------------

--- a/air/Douglas_DC3A.dat
+++ b/air/Douglas_DC3A.dat
@@ -145,14 +145,14 @@ range=2400
 Constraint[Next][0]=none
 Constraint[Prev][0]=none
 
-EmptyImage[E]=./images/Douglas_DC3_Mail.1.2
-EmptyImage[SE]=./images/Douglas_DC3_Mail.1.3
-EmptyImage[S]=./images/Douglas_DC3_Mail.1.4
-EmptyImage[SW]=./images/Douglas_DC3_Mail.1.5
-EmptyImage[W]=./images/Douglas_DC3_Mail.1.6
-EmptyImage[NW]=./images/Douglas_DC3_Mail.1.7
-EmptyImage[N]=./images/Douglas_DC3_Mail.1.0
-EmptyImage[NE]=./images/Douglas_DC3_Mail.1.1
+EmptyImage[E]=./images/Douglas_DC3_mail.1.2
+EmptyImage[SE]=./images/Douglas_DC3_mail.1.3
+EmptyImage[S]=./images/Douglas_DC3_mail.1.4
+EmptyImage[SW]=./images/Douglas_DC3_mail.1.5
+EmptyImage[W]=./images/Douglas_DC3_mail.1.6
+EmptyImage[NW]=./images/Douglas_DC3_mail.1.7
+EmptyImage[N]=./images/Douglas_DC3_mail.1.0
+EmptyImage[NE]=./images/Douglas_DC3_mail.1.1
 
 
 -------------


### PR DESCRIPTION
The mail version of the DC3 is Douglas_DC3_mail.png, not Douglas_DC3_Mail.png. Looking at the other image file names, it might be more correct to rename the file, but this patch will allow it to build.
