### PR TITLE
FIX: added is_tall to double-decker buses

### DIFF
--- a/bus/k-type.dat
+++ b/bus/k-type.dat
@@ -22,6 +22,7 @@ intro_year=1919
 intro_month=8
 retire_year=1923
 retire_month=2
+is_tall=1
 sound=graham-french-leyland-n-type.wav
 
 comfort=22

--- a/bus/leyland-atlantean-an68.dat
+++ b/bus/leyland-atlantean-an68.dat
@@ -200,6 +200,7 @@ intro_year=1974
 intro_month=4
 retire_year=1984
 retire_month=6
+is_tall=1
 sound=leyland-atlantean-an68-ff3170.wav
 
 comfort=41

--- a/bus/leyland-k2.dat
+++ b/bus/leyland-k2.dat
@@ -26,6 +26,7 @@ intro_year=1935
 intro_month=5
 retire_year=1948
 retire_month=6
+is_tall=1
 
 comfort=46
 # Rear platform with conductor 2.0 seconds per passenger

--- a/bus/mcw-q1.dat
+++ b/bus/mcw-q1.dat
@@ -24,6 +24,7 @@ intro_year=1948
 intro_month=1
 retire_year=1966
 retire_month=1
+is_tall=1
 sound=androo4519-btu9613t.wav
 
 # "The Rolls-Royce of trolleybuses"

--- a/bus/ns-type.dat
+++ b/bus/ns-type.dat
@@ -156,6 +156,7 @@ intro_year=1928
 intro_month=7
 retire_year=1931
 retire_month=3
+is_tall=1
 sound=graham-french-tilling-stevens-1930.wav
 
 comfort=35


### PR DESCRIPTION
All double-decker buses should now require tall bridges to pass under.