### PR TITLE
Set GNR Early Tender max speed to 110 km/h to match its fastest locom…

### DIFF
--- a/trains/gnr-early-tender.dat
+++ b/trains/gnr-early-tender.dat
@@ -1,7 +1,7 @@
 obj=vehicle
 name=gnr-early-tender
 engine_type=steam
-speed=100
+speed=110
 copyright=James/jamespetts
 intro_year=1847
 intro_month=8


### PR DESCRIPTION
…otive