### PR TITLE
Add edge_avoidance parameter

### DIFF
--- a/config/cityrules.tab
+++ b/config/cityrules.tab
@@ -20,6 +20,10 @@
 # 80 tiles = 10km at 125m/tile
 minimum_city_distance = 80
 
+# buffer zone on map border where cities should not be built, in tiles
+# a convenience for players to avoid ugly crowding on the map edge
+edge_avoidance = 16
+
 # chance for renovation versus new building (bigger number => less sprawling)
 # Note: the rougher the desired landscape, the lower that this number should be.
 #


### PR DESCRIPTION
This is the pak-side introduction of the edge_avoidance parameter from this code change:

https://github.com/jamespetts/simutrans-extended/pull/605

I think a 16-tile buffer zone from the map edge is suitable for pak128.britain, but whatever you think best.  To not use this at all for a particular pak, set it to 0. 