### PR TITLE
Stone abbey fix

### DIFF
--- a/attractions/stone-attractions.dat
+++ b/attractions/stone-attractions.dat
@@ -988,10 +988,10 @@ Backimage[0][2][1][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[0][2][1][0][0][1]=images/cur/stone-attractions-snow.2.1
 Backimage[0][0][2][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[0][0][2][0][0][1]=images/cur/stone-attractions-snow.2.1
+# The gate tower, orientation 0.  Tricky to align correctly.  Patching can catch the wrong orientation.
 Backimage[0][1][2][0][0][0]=images/cur/stone-attractions.4.1
 Backimage[0][1][2][0][0][1]=images/cur/stone-attractions-snow.4.1
-Backimage[0][1][2][1][0][0]=images/cur/stone-attractions.3.1
-Backimage[0][1][2][1][0][1]=images/cur/stone-attractions-snow.3.1
+# End gate tower orientation 0.
 Backimage[0][2][2][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[0][2][2][0][0][1]=images/cur/stone-attractions-snow.2.1
 
@@ -1001,8 +1001,10 @@ Backimage[1][1][0][0][0][0]=images/cur/stone-attractions.2.0
 Backimage[1][1][0][0][0][1]=images/cur/stone-attractions-snow.2.0
 Backimage[1][2][0][0][0][0]=images/cur/stone-attractions.2.2
 Backimage[1][2][0][0][0][1]=images/cur/stone-attractions-snow.2.2
+# The gate tower, orientation 1.  Tricky to align correctly.  Patching can catch the wrong orientation.
 Backimage[1][0][1][0][0][0]=images/cur/stone-attractions.4.0,44,-22
 Backimage[1][0][1][0][0][1]=images/cur/stone-attractions-snow.4.0,44,-22
+# End gate tower.
 Backimage[1][1][1][0][0][0]=images/cur/stone-attractions.4.7
 Backimage[1][1][1][0][0][1]=images/cur/stone-attractions-snow.4.7
 Backimage[1][2][1][0][0][0]=images/cur/stone-attractions.1.1
@@ -1028,8 +1030,10 @@ Backimage[2][0][1][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[2][0][1][0][0][1]=images/cur/stone-attractions-snow.2.1
 Backimage[2][2][0][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[2][2][0][0][0][1]=images/cur/stone-attractions-snow.2.1
-Backimage[2][1][0][0][0][0]=images/cur/stone-attractions.4.1,44,-22
-Backimage[2][1][0][0][0][1]=images/cur/stone-attractions-snow.4.1,44,-22
+# The gate tower, orientation 2.  Tricky to align correctly.  Patching can catch the wrong orientation.
+Backimage[2][1][0][0][0][0]=images/cur/stone-attractions.4.1,-44,-22
+Backimage[2][1][0][0][0][1]=images/cur/stone-attractions-snow.4.1,-44,-22
+# End gate tower.
 Backimage[2][0][0][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[2][0][0][0][0][1]=images/cur/stone-attractions-snow.2.1
 
@@ -1039,8 +1043,10 @@ Backimage[3][1][0][0][0][0]=images/cur/stone-attractions.2.0
 Backimage[3][1][0][0][0][1]=images/cur/stone-attractions-snow.2.0
 Backimage[3][0][0][0][0][0]=images/cur/stone-attractions.2.2
 Backimage[3][0][0][0][0][1]=images/cur/stone-attractions-snow.2.2
+# The gate tower, orientation 3.  Tricky to align correctly.  Patching can catch the wrong orientation.
 Backimage[3][2][1][0][0][0]=images/cur/stone-attractions.4.0
 Backimage[3][2][1][0][0][1]=images/cur/stone-attractions-snow.4.0
+# End gate tower.
 Backimage[3][1][1][0][0][0]=images/cur/stone-attractions.4.7
 Backimage[3][1][1][0][0][1]=images/cur/stone-attractions-snow.4.7
 Backimage[3][0][1][0][0][0]=images/cur/stone-attractions.1.1

--- a/attractions/stone-attractions.dat
+++ b/attractions/stone-attractions.dat
@@ -1004,7 +1004,7 @@ Backimage[1][2][0][0][0][1]=images/cur/stone-attractions-snow.2.2
 # The gate tower, orientation 1.  Tricky to align correctly.  Patching can catch the wrong orientation.
 Backimage[1][0][1][0][0][0]=images/cur/stone-attractions.4.0,44,-22
 Backimage[1][0][1][0][0][1]=images/cur/stone-attractions-snow.4.0,44,-22
-# End gate tower.
+# End gate tower orientation 1.
 Backimage[1][1][1][0][0][0]=images/cur/stone-attractions.4.7
 Backimage[1][1][1][0][0][1]=images/cur/stone-attractions-snow.4.7
 Backimage[1][2][1][0][0][0]=images/cur/stone-attractions.1.1
@@ -1033,7 +1033,7 @@ Backimage[2][2][0][0][0][1]=images/cur/stone-attractions-snow.2.1
 # The gate tower, orientation 2.  Tricky to align correctly.  Patching can catch the wrong orientation.
 Backimage[2][1][0][0][0][0]=images/cur/stone-attractions.4.1,-44,-22
 Backimage[2][1][0][0][0][1]=images/cur/stone-attractions-snow.4.1,-44,-22
-# End gate tower.
+# End gate tower orientation 2.
 Backimage[2][0][0][0][0][0]=images/cur/stone-attractions.2.1
 Backimage[2][0][0][0][0][1]=images/cur/stone-attractions-snow.2.1
 
@@ -1046,7 +1046,7 @@ Backimage[3][0][0][0][0][1]=images/cur/stone-attractions-snow.2.2
 # The gate tower, orientation 3.  Tricky to align correctly.  Patching can catch the wrong orientation.
 Backimage[3][2][1][0][0][0]=images/cur/stone-attractions.4.0
 Backimage[3][2][1][0][0][1]=images/cur/stone-attractions-snow.4.0
-# End gate tower.
+# End gate tower orientation 3.
 Backimage[3][1][1][0][0][0]=images/cur/stone-attractions.4.7
 Backimage[3][1][1][0][0][1]=images/cur/stone-attractions-snow.4.7
 Backimage[3][0][1][0][0][0]=images/cur/stone-attractions.1.1


### PR DESCRIPTION
..merges from breaking this again.

I FINALLY fixed all four orientations of the stone abbey (Abbey1), which has had odd visual breakage for decades. 

I believe the breakage came from patches and merges in the past, because there's a lot of very similar lines in the stone-monuments file, and patch can find the wrong part of the file if you're not careful.  Accordingly, I added comments to try to make sure this doesn't happen again -- the differing comments should prevent tools like 'patch' from matching on the wrong part of the file.