### PR TITLE
Introduce waggonway dirt road crossing at the same time as waggonway.…

### DIFF
--- a/ways/new-crossing.dat
+++ b/ways/new-crossing.dat
@@ -351,8 +351,8 @@ waytype[1]=track
 waytype[0]=road
 speed[1]=10
 speed[0]=14
-intro_year=1767
-intro_month=4
+intro_year=1700
+intro_month=1
 retire_year=1847
 retire_month=9
 


### PR DESCRIPTION
…  Makes it usable in early game.  There are a lot of public dirt roads at game creation in 1750, which the player is not allowed to delete, and it's impractical to bridge over or under them just for a wooden waggonway.  Of course, waggonways did cross dirt roads, so this is perfectly realistic.